### PR TITLE
Handle ProcessFailedException exceptions

### DIFF
--- a/src/download.jl
+++ b/src/download.jl
@@ -14,10 +14,20 @@ import Dates: unix2datetime, now
 else
     function _download(url::AbstractString, filename::AbstractString,
         verbose::Bool)
-        if verbose
-            run(`curl -o $filename -L $url`)
-        else
-            run(`curl -s -o $filename -L $url`)
+        try
+            if verbose
+                run(`curl -o $filename -L $url`)
+            else
+                run(`curl -s -o $filename -L $url`)
+            end
+        catch err
+            # handle julia 1.2 changing error type for failing processes
+            # https://github.com/JuliaLang/julia/pull/27900
+            if isdefined(Base, :ProcessFailedException) && err isa ProcessFailedException
+                error(sprint(showerror, err))
+            else
+                return err
+            end
         end
     end
 end


### PR DESCRIPTION
In https://github.com/JuliaLang/julia/pull/27900
`run` was changet to throw a `ProcessFailedException` rather than a `ErrorException`, if the process (e.g. curl/wget) returned a nonzero exit code.

One of the things not covered by julia semver was exceptions.
i.e. the type of an exception can change on minor releases.
Now of-course we don't want to make a release of julia that does break peoples plackages,
so It would be good to fix this.
Ergo this PR.