### PR TITLE
add -R -z in curl

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -6,7 +6,7 @@ abstract type AbstractBackend end
 struct CURL <: AbstractBackend end
 nameof(::CURL) = "cURL"
 
-function download(::CURL, url, filename; verbose::Bool = false)
+function download(::CURL, url, filename; verbose::Bool=false)
     curl = Sys.which("curl")
     curl === nothing && error("The `curl` executable was not found.")
     try
@@ -28,7 +28,7 @@ end
 struct Wget <: AbstractBackend end
 nameof(::Wget) = "wget"
 
-function download(::Wget, url, filename; verbose::Bool = false)
+function download(::Wget, url, filename; verbose::Bool=false)
     wget = Sys.which("wget")
     wget === nothing && error("The `wget` executable was not found.")
     try
@@ -52,12 +52,12 @@ nameof(::Http) = "HTTP.jl"
 
 const HEADERS = ["User-Agent" => "RemoteFiles.jl/0.3 (+https://github.com/helgee/RemoteFiles.jl)", "Accept" => "*/*"]
 
-function download(::Http, url, filename; verbose::Bool = false)
+function download(::Http, url, filename; verbose::Bool=false)
     try
         if verbose
             HTTP.download(url, filename, HEADERS)
         else
-            HTTP.download(url, filename, HEADERS; update_period = typemax(Int))
+            HTTP.download(url, filename, HEADERS; update_period=typemax(Int))
         end
     catch err
         throw(DownloadError((sprint(showerror, err))))

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -6,14 +6,14 @@ abstract type AbstractBackend end
 struct CURL <: AbstractBackend end
 nameof(::CURL) = "cURL"
 
-function download(::CURL, url, filename; verbose::Bool=false)
+function download(::CURL, url, filename; verbose::Bool = false)
     curl = Sys.which("curl")
     curl === nothing && error("The `curl` executable was not found.")
     try
         if verbose
-            run(`$curl -o $filename -L $url`)
+            run(`$curl -R -z $filename -o $filename -L $url`)
         else
-            run(`$curl -s -o $filename -L $url`)
+            run(`$curl -s -R -z $filename -o $filename -L $url`)
         end
     catch err
         if (isdefined(Base, :ProcessFailedException) &&
@@ -28,7 +28,7 @@ end
 struct Wget <: AbstractBackend end
 nameof(::Wget) = "wget"
 
-function download(::Wget, url, filename; verbose::Bool=false)
+function download(::Wget, url, filename; verbose::Bool = false)
     wget = Sys.which("wget")
     wget === nothing && error("The `wget` executable was not found.")
     try
@@ -52,12 +52,12 @@ nameof(::Http) = "HTTP.jl"
 
 const HEADERS = ["User-Agent" => "RemoteFiles.jl/0.3 (+https://github.com/helgee/RemoteFiles.jl)", "Accept" => "*/*"]
 
-function download(::Http, url, filename; verbose::Bool=false)
+function download(::Http, url, filename; verbose::Bool = false)
     try
         if verbose
             HTTP.download(url, filename, HEADERS)
         else
-            HTTP.download(url, filename, HEADERS; update_period=typemax(Int))
+            HTTP.download(url, filename, HEADERS; update_period = typemax(Int))
         end
     catch err
         throw(DownloadError((sprint(showerror, err))))


### PR DESCRIPTION
Add two parameters in curl command.

I think using timestemp of a `RemoteFile` might be better for `RemoteFiles.jl` package.


The description in [curl.haxx.se](https://curl.haxx.se/docs/manpage.html)
```
-R, --remote-time

When used, this will make curl attempt to figure out the timestamp of the remote file, and if that is available make the local file get that same timestamp. 

-z, --time-cond <time>

(HTTP FTP) Request a file that has been modified later than the given time and date, or one that has been modified before that time. The <date expression> can be all sorts of date strings or if it doesn't match any internal ones, it is taken as a filename and tries to get the modification date (mtime) from <file> instead. See the curl_getdate(3) man pages for date expression details.

Start the date expression with a dash (-) to make it request for a document that is older than the given date/time, default is a document that is newer than the specified date/time.

If this option is used several times, the last one will be used.
```

The timestamp could be found as follow:

```
curl -I https://curl.haxx.se/

HTTP/2 200 
server: Apache
x-frame-options: SAMEORIGIN
last-modified: Mon, 27 Apr 2020 02:13:49 GMT
etag: "21e7-5a43c43fc71bf"
cache-control: max-age=60
expires: Mon, 27 Apr 2020 02:15:10 GMT
x-content-type-options: nosniff
content-security-policy: default-src 'self' www.fastly-insights.com; style-src 'unsafe-inline' 'self'
strict-transport-security: max-age=31536000; includeSubDomains;
content-type: text/html
via: 1.1 varnish
accept-ranges: bytes
date: Mon, 27 Apr 2020 03:19:49 GMT
via: 1.1 varnish
age: 23
x-served-by: cache-bma1641-BMA, cache-tyo19944-TYO
x-cache: HIT, MISS
x-cache-hits: 1, 0
x-timer: S1587957589.889921,VS0,VE1073
vary: Accept-Encoding
content-length: 8679
```
`Last-Modified` in `HTTP` standard could be found in [w3.org](https://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)

```
14.29 Last-Modified
The Last-Modified entity-header field indicates the date and time at which the origin server believes the variant was last modified.

       Last-Modified  = "Last-Modified" ":" HTTP-date
An example of its use is

       Last-Modified: Tue, 15 Nov 1994 12:45:26 GMT
The exact meaning of this header field depends on the implementation of the origin server and the nature of the original resource. For files, it may be just the file system last-modified time. For entities with dynamically included parts, it may be the most recent of the set of last-modify times for its component parts. For database gateways, it may be the last-update time stamp of the record. For virtual objects, it may be the last time the internal state changed.

An origin server MUST NOT send a Last-Modified date which is later than the server's time of message origination. In such cases, where the resource's last modification would indicate some time in the future, the server MUST replace that date with the message origination date.

An origin server SHOULD obtain the Last-Modified value of the entity as close as possible to the time that it generates the Date value of its response. This allows a recipient to make an accurate assessment of the entity's modification time, especially if the entity changes near the time that the response is generated.

HTTP/1.1 servers SHOULD send Last-Modified whenever feasible.
```