### PR TITLE
RFC: Backend choice part of RemoteFile

### DIFF
--- a/src/RemoteFiles.jl
+++ b/src/RemoteFiles.jl
@@ -11,7 +11,7 @@ export DownloadError, RemoteFile, @RemoteFile, path, rm, isfile,
 
 include("backends.jl")
 
-"The list of supported backends on current machine"
+"The list of supported backends on the current machine"
 const BACKENDS = AbstractBackend[Http()]
 
 _iscurl(curl) = occursin("libcurl", read(`$curl --version`, String))
@@ -110,7 +110,7 @@ The following keyword arguments are available:
     - `:mondays`/`:weekly`, `:tuesdays`, etc.
 - `retries` (default: 3): How many retries should be attempted.
 - `try_backends` (default: `true`): Whether to retry with different backends.
-- `backends` (default `RemoteFiles.BACKENDS`): which backends to try.
+- `backends` (default `RemoteFiles.BACKENDS`): Which backends to try.
 - `wait` (default: 5): How many seconds to wait between retries.
 - `failed` (default: `:error`): What to do if the download fails. Either throw
     an exception (`:error`) or display a warning (`:warn`).

--- a/src/RemoteFiles.jl
+++ b/src/RemoteFiles.jl
@@ -11,6 +11,7 @@ export DownloadError, RemoteFile, @RemoteFile, path, rm, isfile,
 
 include("backends.jl")
 
+"The list of supported backends on current machine"
 const BACKENDS = AbstractBackend[Http()]
 
 _iscurl(curl) = occursin("libcurl", read(`$curl --version`, String))
@@ -34,6 +35,7 @@ struct RemoteFile
     updates::Symbol
     retries::Int
     try_backends::Bool
+    backends::Vector{AbstractBackend}
     wait::Int
     failed::Symbol
 end
@@ -51,6 +53,7 @@ function RemoteFile(uri::URI;
     updates::Symbol=:never,
     retries::Int=3,
     try_backends::Bool=true,
+    backends=BACKENDS,
     wait::Int=5,
     failed::Symbol=:error,
 )
@@ -64,7 +67,7 @@ function RemoteFile(uri::URI;
         end
     end
 
-    RemoteFile(uri, file, abspath(dir), updates, retries, try_backends, wait, failed)
+    RemoteFile(uri, file, abspath(dir), updates, retries, try_backends, backends, wait, failed)
 end
 RemoteFile(uri::String; kwargs...) = RemoteFile(URI(uri); kwargs...)
 
@@ -107,6 +110,7 @@ The following keyword arguments are available:
     - `:mondays`/`:weekly`, `:tuesdays`, etc.
 - `retries` (default: 3): How many retries should be attempted.
 - `try_backends` (default: `true`): Whether to retry with different backends.
+- `backends` (default `RemoteFiles.BACKENDS`): which backends to try.
 - `wait` (default: 5): How many seconds to wait between retries.
 - `failed` (default: `:error`): What to do if the download fails. Either throw
     an exception (`:error`) or display a warning (`:warn`).

--- a/src/download.jl
+++ b/src/download.jl
@@ -16,7 +16,7 @@ Download `rf`.
 - `retries`: Override the number of retries in `rf` if `retries != 0`
 """
 function download(rf::RemoteFile; kwargs...)
-    for (i, backend) in enumerate(BACKENDS)
+    for (i, backend) in enumerate(rf.backends)
         try
             if i == 1
                 download(backend, rf; kwargs...)
@@ -99,4 +99,3 @@ function samecontent(file1, file2)
     h2 = hash(open(read, file2, "r"))
     h1 == h2
 end
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,9 +30,9 @@ rm("tmp", force=true, recursive=true)
         @test r.file == "image.png"
 
 
-		@test_logs((:info, r"Downloading file 'image.png' from 'https://httpbin.org/image/png'."),
-			(:info, r"File 'image.png' was successfully downloaded."),
-			match_mode=:any, download(r, verbose=true))
+	@test_logs((:info, r"Downloading file 'image.png' from 'https://httpbin.org/image/png'."),
+		   (:info, r"File 'image.png' was successfully downloaded."),
+		   match_mode=:any, download(r, verbose=true))
         @test isfile(r)
         rm(r, force=true)
 
@@ -92,6 +92,31 @@ rm("tmp", force=true, recursive=true)
         @test isfile(r)
         @test isfile(r1)
         rm(dir, force=true, recursive=true)
+    end
+    @testset "RemoteFile backends" begin
+        r = RemoteFile("https://httpbin.org/image/png", backends=[RemoteFiles.Http()], file="image.png")
+	@test_logs((:info, r"Downloading file 'image.png' from 'https://httpbin.org/image/png'."),
+		   (:info, r"File 'image.png' was successfully downloaded."),
+		   match_mode=:any, download(r, verbose=true))
+        @test isfile(r)
+        rm(r, force=true)
+
+        if RemoteFiles.CURL() in RemoteFiles.BACKENDS
+            r = RemoteFile("https://httpbin.org/image/png", backends=[RemoteFiles.CURL()], file="image.png")
+	    @test_logs((:info, r"Downloading file 'image.png' from 'https://httpbin.org/image/png'."),
+		       (:info, r"File 'image.png' was successfully downloaded."),
+		       match_mode=:any, download(r, verbose=true))
+            @test isfile(r)
+            rm(r, force=true)
+        end
+        if RemoteFiles.Wget() in RemoteFiles.BACKENDS
+            r = RemoteFile("https://httpbin.org/image/png", backends=[RemoteFiles.Wget()], file="image.png")
+	    @test_logs((:info, r"Downloading file 'image.png' from 'https://httpbin.org/image/png'."),
+		       (:info, r"File 'image.png' was successfully downloaded."),
+		       match_mode=:any, download(r, verbose=true))
+            @test isfile(r)
+            rm(r, force=true)
+        end
     end
     @testset "RemoteFileSets" begin
         set = RemoteFileSet("Images",


### PR DESCRIPTION
This gives:
```julia
r = RemoteFile("https://httpbin.org/image/png", backends=[RemoteFiles.CURL()], file="image.png")
```

The kwarg backends is now a bit redundant with `try_backends`.  Thus I would favor removing `try_backends` but that would be breaking.  Let me know what you think.

The reason I want this is because one file I got can only be downloaded with wget, but as curl is installed on my system it will not get to wget.