### PR TITLE
Add option to force overwritting downloaded file

### DIFF
--- a/src/download.jl
+++ b/src/download.jl
@@ -13,6 +13,7 @@ Download `rf`.
 - `quiet`: Do not print messages.
 - `verbose`: Print all messages.
 - `force`: Force download and overwrite existing files.
+- `force_update`: Overwrite existing files even if they are equal.
 - `retries`: Override the number of retries in `rf` if `retries != 0`
 """
 function download(rf::RemoteFile; kwargs...)
@@ -33,7 +34,7 @@ function download(rf::RemoteFile; kwargs...)
 end
 
 function download(backend, rf::RemoteFile; verbose::Bool=false, quiet::Bool=false,
-    force::Bool=false, retries::Int=0)
+    force::Bool=false, force_update::Bool=false, retries::Int=0)
     file = joinpath(rf.dir, rf.file)
     retries = retries != 0 ? retries : rf.retries
 
@@ -74,7 +75,7 @@ function download(backend, rf::RemoteFile; verbose::Bool=false, quiet::Bool=fals
     if success
         update = true
         if isfile(file) && !force
-            if samecontent(tempfile, file)
+            if !force_update && samecontent(tempfile, file)
                 update = false
                 verbose && @info "File '$(rf.file)' has not changed. Update skipped."
             else


### PR DESCRIPTION
Hi @helgee !

Your code is very clean! I could fix the problem myself. I added an option `force_update` that forces overwriting the file every time it is downloaded, updating the timestamp. Is it acceptable?

Closes #21