### PR TITLE
Update http

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,7 +9,7 @@ HTTP = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 
 [compat]
 FileIO = "1.6"
-HTTP = "0.9"
+HTTP = "1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
This version of http is old and this can break dependencies. All unit tests still pass with the new version.